### PR TITLE
Support regex expression in upload URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The first step is to create a `TusFileUploadService` object using its constructo
 
 * `withUploadURI(String)`: Set the relative URL under which the main tus upload endpoint will be made available, for example `/files/upload`. Optionally, this URI may contain regex parameters in order to support endpoints that contain URL parameters, for example `/users/[0-9]+/files/upload`.
 * `withMaxUploadSize(Long)`: Specify the maximum number of bytes that can be uploaded per upload. If you don't call this method, the maximum number of bytes is `Long.MAX_VALUE`.
-* `withStoragePath(String)`: If you're using the default filesystem-based storage service, you can use this method to specify the path where to store the uploaded bytes and upload information.
+* `withStoragePath(String)`: If you're using the default file system-based storage service, you can use this method to specify the path where to store the uploaded bytes and upload information.
 * `withChunkedTransferDecoding`: You can enable or disable the decoding of chunked HTTP requests by this library. Enable this feature in case the web container in which this service is running does not decode chunked transfers itself. By default, chunked decoding via this library is disabled (as modern frameworks tend to already do this for you).
 * `withThreadLocalCache(Boolean)`: Optionally you can enable (or disable) an in-memory (thread local) cache of upload request data to reduce load on the storage backend and potentially increase performance when processing upload requests.
 * `withUploadExpirationPeriod(Long)`: You can set the number of milliseconds after which an upload is considered as expired and available for cleanup.
@@ -49,7 +49,7 @@ The first step is to create a `TusFileUploadService` object using its constructo
 * `disableTusExtension(String)`: Disable the `TusExtension` for which the `getName()` method matches the provided string. The default extensions have names "creation", "checksum", "expiration", "concatenation", "termination" and "download". You cannot disable the "core" feature.
 
 
-For now this library only provides filesystem-based storage and locking options. You can however provide your own implementation of a `UploadStorageService` and `UploadLockingService` using the methods `withUploadStorageService(UploadStorageService)` and `withUploadLockingService(UploadLockingService)` in order to support different types of upload storage.
+For now this library only provides file system-based storage and locking options. You can however provide your own implementation of a `UploadStorageService` and `UploadLockingService` using the methods `withUploadStorageService(UploadStorageService)` and `withUploadLockingService(UploadLockingService)` in order to support different types of upload storage.
 
 ### 2. Processing an upload
 To process an upload request you have to pass the current `javax.servlet.http.HttpServletRequest` and `javax.servlet.http.HttpServletResponse` objects to the `me.desair.tus.server.TusFileUploadService.process()` method. Typical places were you can do this are inside Servlets, Filters or REST API Controllers (see [examples](#quick-start-and-examples)).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Besides the [core protocol](https://tus.io/protocols/resumable-upload.html#core-
 ### 1. Setup
 The first step is to create a `TusFileUploadService` object using its constructor. You can make this object available as a (Spring bean) singleton or create a new instance for each request. After creating the object, you can configure it using the following methods:
 
-* `withUploadURI(String)`: Set the relative URL under which the tus upload endpoint will be made available, for example `/files/upload`.
+* `withUploadURI(String)`: Set the relative URL under which the main tus upload endpoint will be made available, for example `/files/upload`. Optionally, this URI may contain regex parameters in order to support endpoints that contain URL parameters, for example `/users/[0-9]+/files/upload`.
 * `withMaxUploadSize(Long)`: Specify the maximum number of bytes that can be uploaded per upload. If you don't call this method, the maximum number of bytes is `Long.MAX_VALUE`.
 * `withStoragePath(String)`: If you're using the default filesystem-based storage service, you can use this method to specify the path where to store the uploaded bytes and upload information.
 * `withChunkedTransferDecoding`: You can enable or disable the decoding of chunked HTTP requests by this library. Enable this feature in case the web container in which this service is running does not decode chunked transfers itself. By default, chunked decoding via this library is disabled (as modern frameworks tend to already do this for you).

--- a/src/main/java/me/desair/tus/server/TusFileUploadService.java
+++ b/src/main/java/me/desair/tus/server/TusFileUploadService.java
@@ -130,7 +130,7 @@ public class TusFileUploadService {
     }
 
     /**
-     * If you're using the default filesystem-based storage service, you can use this method to
+     * If you're using the default file system-based storage service, you can use this method to
      * specify the path where to store the uploaded bytes and upload information.
      *
      * @param storagePath The file system path where uploads can be stored (temporarily)
@@ -192,9 +192,9 @@ public class TusFileUploadService {
     }
 
     /**
-     * Add a custom (application-specific) extension that implements the `me.desair.tus.server.TusExtension` interface.
-     * For example you can add your own extension that checks authentication and authorization policies within your
-     * application for the user doing the upload.
+     * Add a custom (application-specific) extension that implements the {@link me.desair.tus.server.TusExtension}
+     * interface. For example you can add your own extension that checks authentication and authorization policies
+     * within your application for the user doing the upload.
      *
      * @param feature The custom extension implementation
      * @return The current service

--- a/src/main/java/me/desair/tus/server/TusFileUploadService.java
+++ b/src/main/java/me/desair/tus/server/TusFileUploadService.java
@@ -68,7 +68,7 @@ public class TusFileUploadService {
     }
 
     public TusFileUploadService withUploadURI(String uploadURI) {
-        Validate.notBlank(uploadURI, "The upload URI cannot be blank");
+        Validate.notBlank(uploadURI, "The upload URI pattern cannot be blank");
         this.idFactory.setUploadURI(uploadURI);
         return this;
     }

--- a/src/main/java/me/desair/tus/server/creation/validation/PostURIValidator.java
+++ b/src/main/java/me/desair/tus/server/creation/validation/PostURIValidator.java
@@ -1,5 +1,8 @@
 package me.desair.tus.server.creation.validation;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.servlet.http.HttpServletRequest;
 
 import me.desair.tus.server.HttpMethod;
@@ -7,19 +10,22 @@ import me.desair.tus.server.RequestValidator;
 import me.desair.tus.server.exception.PostOnInvalidRequestURIException;
 import me.desair.tus.server.exception.TusException;
 import me.desair.tus.server.upload.UploadStorageService;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * The Client MUST send a POST request against a known upload creation URL to request a new upload resource.
  */
 public class PostURIValidator implements RequestValidator {
 
+    private Pattern uploadUriPattern = null;
+
     @Override
     public void validate(HttpMethod method, HttpServletRequest request,
                          UploadStorageService uploadStorageService, String ownerKey)
             throws TusException {
 
-        if (!StringUtils.equals(request.getRequestURI(), uploadStorageService.getUploadURI())) {
+        Matcher uploadUriMatcher = getUploadUriPattern(uploadStorageService).matcher(request.getRequestURI());
+
+        if (!uploadUriMatcher.matches()) {
             throw new PostOnInvalidRequestURIException("POST requests have to be send to "
                     + uploadStorageService.getUploadURI());
         }
@@ -28,6 +34,14 @@ public class PostURIValidator implements RequestValidator {
     @Override
     public boolean supports(HttpMethod method) {
         return HttpMethod.POST.equals(method);
+    }
+
+    private Pattern getUploadUriPattern(UploadStorageService uploadStorageService) {
+        if (uploadUriPattern == null) {
+            //A POST request should match the full URI
+            uploadUriPattern = Pattern.compile("^" + uploadStorageService.getUploadURI() + "$");
+        }
+        return uploadUriPattern;
     }
 
 }

--- a/src/main/java/me/desair/tus/server/upload/UploadIdFactory.java
+++ b/src/main/java/me/desair/tus/server/upload/UploadIdFactory.java
@@ -7,17 +7,39 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 
+/**
+ * Factory to create unique upload IDs. This factory can also parse the upload identifier
+ * from a given upload URL.
+ */
 public class UploadIdFactory {
 
     private String uploadURI = "/";
     private Pattern uploadUriPattern = null;
 
+    /**
+     * Set the URI under which the main tus upload endpoint is hosted.
+     * Optionally, this URI may contain regex parameters in order to support endpoints that contain
+     * URL parameters, for example /users/[0-9]+/files/upload
+     *
+     * @param uploadURI The URI of the main tus upload endpoint
+     */
     public void setUploadURI(String uploadURI) {
-        Validate.notNull(uploadURI, "The upload URI pattern cannot be null");
+        Validate.notBlank(uploadURI, "The upload URI pattern cannot be blank");
+        Validate.isTrue(StringUtils.startsWith(uploadURI, "/"), "The upload URI should start with /");
+        Validate.isTrue(!StringUtils.endsWith(uploadURI, "$"), "The upload URI should not end with $");
         this.uploadURI = uploadURI;
         this.uploadUriPattern = null;
     }
 
+    /**
+     * Read the upload identifier from the given URL.
+     * <p/>
+     * Clients will send requests to upload URLs or provided URLs of completed uploads. This method is able to
+     * parse those URLs and provide the user with the corresponding upload ID.
+     *
+     * @param url The URL provided by the client
+     * @return The corresponding Upload identifier
+     */
     public UUID readUploadId(String url) {
         Matcher uploadUriMatcher = getUploadUriPattern().matcher(StringUtils.trimToEmpty(url));
         String pathId = uploadUriMatcher.replaceFirst("");
@@ -34,10 +56,18 @@ public class UploadIdFactory {
         return id;
     }
 
+    /**
+     * Return the URI of the main tus upload endpoint. Note that this value possibly contains regex parameters.
+     * @return The URI of the main tus upload endpoint.
+     */
     public String getUploadURI() {
         return uploadURI;
     }
 
+    /**
+     * Create a new unique upload ID
+     * @return A new unique upload ID
+     */
     public synchronized UUID createId() {
         return UUID.randomUUID();
     }

--- a/src/main/java/me/desair/tus/server/upload/UploadIdFactory.java
+++ b/src/main/java/me/desair/tus/server/upload/UploadIdFactory.java
@@ -1,6 +1,8 @@
 package me.desair.tus.server.upload;
 
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -8,14 +10,17 @@ import org.apache.commons.lang3.Validate;
 public class UploadIdFactory {
 
     private String uploadURI = "/";
+    private Pattern uploadUriPattern = null;
 
     public void setUploadURI(String uploadURI) {
-        Validate.notNull(uploadURI, "The upload URI cannot be null");
+        Validate.notNull(uploadURI, "The upload URI pattern cannot be null");
         this.uploadURI = uploadURI;
+        this.uploadUriPattern = null;
     }
 
     public UUID readUploadId(String url) {
-        String pathId = StringUtils.substringAfter(url, uploadURI + (StringUtils.endsWith(uploadURI, "/") ? "" : "/"));
+        Matcher uploadUriMatcher = getUploadUriPattern().matcher(StringUtils.trimToEmpty(url));
+        String pathId = uploadUriMatcher.replaceFirst("");
         UUID id = null;
 
         if (StringUtils.isNotBlank(pathId)) {
@@ -35,5 +40,15 @@ public class UploadIdFactory {
 
     public synchronized UUID createId() {
         return UUID.randomUUID();
+    }
+
+    private Pattern getUploadUriPattern() {
+        if (uploadUriPattern == null) {
+            //We will extract the upload ID's by removing the upload URI from the start of the request URI
+            uploadUriPattern = Pattern.compile("^.*"
+                    + uploadURI
+                    + (StringUtils.endsWith(uploadURI, "/") ? "" : "/?"));
+        }
+        return uploadUriPattern;
     }
 }

--- a/src/test/java/me/desair/tus/server/ITTusFileUploadService.java
+++ b/src/test/java/me/desair/tus/server/ITTusFileUploadService.java
@@ -1157,20 +1157,20 @@ public class ITTusFileUploadService {
     }
 
     @Test
-    public void testChunkedDecodingDisabled() throws Exception {
+    public void testChunkedDecodingDisabledAndRegexUploadURI() throws Exception {
         String chunkedContent = "1B;test=value\r\nThis upload looks chunked, \r\n"
                 + "D\r\nbut it's not!\r\n"
                 + "\r\n0\r\n";
 
         //Create service without chunked decoding
         tusFileUploadService = new TusFileUploadService()
-                .withUploadURI(UPLOAD_URI)
+                .withUploadURI("/users/[0-9]+/files/upload")
                 .withStoragePath(storagePath.toAbsolutePath().toString())
                 .withDownloadFeature();
 
         //Create upload
         servletRequest.setMethod("POST");
-        servletRequest.setRequestURI(UPLOAD_URI);
+        servletRequest.setRequestURI("/users/98765/files/upload");
         servletRequest.addHeader(HttpHeader.CONTENT_LENGTH, 0);
         servletRequest.addHeader(HttpHeader.UPLOAD_LENGTH, "67");
         servletRequest.addHeader(HttpHeader.TUS_RESUMABLE, "1.0.0");
@@ -1183,8 +1183,7 @@ public class ITTusFileUploadService {
         assertResponseHeaderNull(HttpHeader.UPLOAD_EXPIRES);
         assertResponseStatus(HttpServletResponse.SC_CREATED);
 
-        String location = UPLOAD_URI +
-                StringUtils.substringAfter(servletResponse.getHeader(HttpHeader.LOCATION), UPLOAD_URI);
+        String location = servletResponse.getHeader(HttpHeader.LOCATION);
 
         //Upload content
         reset();

--- a/src/test/java/me/desair/tus/server/creation/validation/PostURIValidatorTest.java
+++ b/src/test/java/me/desair/tus/server/creation/validation/PostURIValidatorTest.java
@@ -66,4 +66,38 @@ public class PostURIValidatorTest {
 
         //Expect PostOnInvalidRequestURIException
     }
+
+    @Test
+    public void validateMatchingRegexUrl() throws Exception {
+        servletRequest.setRequestURI("/users/1234/files/upload");
+        when(uploadStorageService.getUploadURI()).thenReturn("/users/[0-9]+/files/upload");
+
+        try {
+            validator.validate(HttpMethod.POST, servletRequest, uploadStorageService, null);
+        } catch (Exception ex) {
+            fail();
+        }
+
+        //No Exception is thrown
+    }
+
+    @Test(expected = PostOnInvalidRequestURIException.class)
+    public void validateInvalidRegexUrl() throws Exception {
+        servletRequest.setRequestURI("/users/abc123/files/upload");
+        when(uploadStorageService.getUploadURI()).thenReturn("/users/[0-9]+/files/upload");
+
+        validator.validate(HttpMethod.POST, servletRequest, uploadStorageService, null);
+
+        //Expect PostOnInvalidRequestURIException
+    }
+
+    @Test(expected = PostOnInvalidRequestURIException.class)
+    public void validateInvalidRegexUrlPatchUrl() throws Exception {
+        servletRequest.setRequestURI("/users/1234/files/upload/7669c72a-3f2a-451f-a3b9-9210e7a4c02f");
+        when(uploadStorageService.getUploadURI()).thenReturn("/users/[0-9]+/files/upload");
+
+        validator.validate(HttpMethod.POST, servletRequest, uploadStorageService, null);
+
+        //Expect PostOnInvalidRequestURIException
+    }
 }

--- a/src/test/java/me/desair/tus/server/upload/UploadIdFactoryTest.java
+++ b/src/test/java/me/desair/tus/server/upload/UploadIdFactoryTest.java
@@ -35,6 +35,21 @@ public class UploadIdFactoryTest {
         assertThat(idFactory.getUploadURI(), is("/test/upload/"));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void setUploadURIBlank() throws Exception {
+        idFactory.setUploadURI(" ");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setUploadURINoStartingSlash() throws Exception {
+        idFactory.setUploadURI("test/upload/");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setUploadURIEndsWithDollar() throws Exception {
+        idFactory.setUploadURI("/test/upload$");
+    }
+
     @Test
     public void readUploadId() throws Exception {
         idFactory.setUploadURI("/test/upload");

--- a/src/test/java/me/desair/tus/server/upload/UploadIdFactoryTest.java
+++ b/src/test/java/me/desair/tus/server/upload/UploadIdFactoryTest.java
@@ -44,6 +44,14 @@ public class UploadIdFactoryTest {
     }
 
     @Test
+    public void readUploadIdRegex() throws Exception {
+        idFactory.setUploadURI("/users/[0-9]+/files/upload");
+
+        assertThat(idFactory.readUploadId("/users/1337/files/upload/1911e8a4-6939-490c-b58b-a5d70f8d91fb"),
+                hasToString("1911e8a4-6939-490c-b58b-a5d70f8d91fb"));
+    }
+
+    @Test
     public void readUploadIdTrailingSlash() throws Exception {
         idFactory.setUploadURI("/test/upload/");
 
@@ -52,10 +60,26 @@ public class UploadIdFactoryTest {
     }
 
     @Test
+    public void readUploadIdRegexTrailingSlash() throws Exception {
+        idFactory.setUploadURI("/users/[0-9]+/files/upload/");
+
+        assertThat(idFactory.readUploadId("/users/123456789/files/upload/1911e8a4-6939-490c-b58b-a5d70f8d91fb"),
+                hasToString("1911e8a4-6939-490c-b58b-a5d70f8d91fb"));
+    }
+
+    @Test
     public void readUploadIdNoUUID() throws Exception {
         idFactory.setUploadURI("/test/upload");
 
         assertThat(idFactory.readUploadId("/test/upload/not-a-uuid-value"), is(nullValue()));
+    }
+
+    @Test
+    public void readUploadIdRegexNoMatch() throws Exception {
+        idFactory.setUploadURI("/users/[0-9]+/files/upload");
+
+        assertThat(idFactory.readUploadId("/users/files/upload/1911e8a4-6939-490c-b58b-a5d70f8d91fb"),
+                is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
In order to solve issue https://github.com/tomdesair/tus-java-server/issues/11, I've updated the code so that the upload URI is considered as a regex. This is a backwards compatible change.

That way, frameworks that use URL parameters in the upload endpoint can specify a regex upload URI. The example parameterized URL from the issue is `/users/{userId}/files/upload`. This then corresponds to the regex upload URI: `/users/[0-9]+/files/upload`.