### PR TITLE
Replaces javax.xml.bind.DatatypeConverter with apache commons Base64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
             <version>2.6</version>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.11</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>

--- a/src/main/java/me/desair/tus/server/upload/UploadInfo.java
+++ b/src/main/java/me/desair/tus/server/upload/UploadInfo.java
@@ -9,8 +9,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
 
-import javax.xml.bind.DatatypeConverter;
-
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -254,7 +253,7 @@ public class UploadInfo implements Serializable {
         if (encodedValue == null) {
             return null;
         } else {
-            return new String(DatatypeConverter.parseBase64Binary(encodedValue), Charset.forName("UTF-8"));
+            return new String(Base64.decodeBase64(encodedValue), Charset.forName("UTF-8"));
         }
     }
 }

--- a/src/main/java/me/desair/tus/server/util/TusServletRequest.java
+++ b/src/main/java/me/desair/tus/server/util/TusServletRequest.java
@@ -15,13 +15,14 @@ import java.util.TreeSet;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
-import javax.xml.bind.DatatypeConverter;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.input.CountingInputStream;
+import org.apache.commons.lang3.StringUtils;
 
 import me.desair.tus.server.HttpHeader;
 import me.desair.tus.server.TusExtension;
 import me.desair.tus.server.checksum.ChecksumAlgorithm;
-import org.apache.commons.io.input.CountingInputStream;
-import org.apache.commons.lang3.StringUtils;
 
 public class TusServletRequest extends HttpServletRequestWrapper {
 
@@ -106,7 +107,7 @@ public class TusServletRequest extends HttpServletRequestWrapper {
     public String getCalculatedChecksum(ChecksumAlgorithm algorithm) {
         MessageDigest messageDigest = getMessageDigest(algorithm);
         return messageDigest == null ? null :
-                DatatypeConverter.printBase64Binary(messageDigest.digest());
+                Base64.encodeBase64String(messageDigest.digest());
     }
 
     /**


### PR DESCRIPTION
To not depend on `javax.xml.bind` package which is not included in java 11, I replaced the `DatatypeConverter` for Base64 en-/decoding with the Base64 encoder from apache commons-codec.
When the project removes java 1.7 support it could also the java.util.Base64 encoder from java 8 be used. 

Tests do not run with jdk11 because there are some problems with the surefire and jacoco maven plugin.