### PR TITLE
Changed oraclejdk9 to openjdk9 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 sudo: false # faster builds
 
 jdk:
+- openjdk12
 - oraclejdk11
 - openjdk9
 - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false # faster builds
 
 jdk:
 - oraclejdk11
-- oraclejdk9
+- openjdk9
 - openjdk8
 # https://docs.travis-ci.com/user/languages/java/#testing-against-multiple-jdks
 # - Oracle JDK 10 is not provided because it reached End of Life in October 2018.

--- a/src/main/java/me/desair/tus/server/upload/UploadId.java
+++ b/src/main/java/me/desair/tus/server/upload/UploadId.java
@@ -33,7 +33,7 @@ public class UploadId implements Serializable {
         URLCodec codec = new URLCodec();
         //Check if value is not encoded already
         try {
-            if (inputValue.equals(codec.decode(inputValue, UPLOAD_ID_CHARSET))) {
+            if (inputValue != null && inputValue.equals(codec.decode(inputValue, UPLOAD_ID_CHARSET))) {
                 this.urlSafeValue = codec.encode(inputValue, UPLOAD_ID_CHARSET);
             } else {
                 //value is already encoded, use as is


### PR DESCRIPTION
Changed oraclejdk9 to openjdk9 because of Travis image change: https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment