### PR TITLE
Update GitHub Actions workflows to use Java 21 and 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
   mvn-install:
     strategy:
       matrix:
-        java: [17]
+        java: [21, 25]
         os: [ubuntu-latest, windows-latest]
         include:
           - os: ubuntu-latest
-            java: 17
+            java: 25
             upload-dependency-graph: true
             run-sonarcloud: true
             run-coveralls: true

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
-          java-version: "17"
+          java-version: "25"
           distribution: "temurin"
           cache: maven
       - name: Check codestyle with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@
                     <plugin>
                         <groupId>com.spotify.fmt</groupId>
                         <artifactId>fmt-maven-plugin</artifactId>
-                        <version>2.20</version>
+                        <version>2.27</version>
                         <configuration>
                             <style>google</style>
                         </configuration>


### PR DESCRIPTION
Updates the build and codestyle GitHub Actions workflows to use the latest Java LTS versions (21 and 25) as requested. The build matrix is updated to include 21 and 25, and the specific include step and the codestyle check are updated to use Java 25.

---
*PR created automatically by Jules for task [9391960122288878008](https://jules.google.com/task/9391960122288878008) started by @tomdesair*