### PR TITLE
FIx: Issue 73

### DIFF
--- a/src/main/java/me/desair/tus/server/upload/UploadInfo.java
+++ b/src/main/java/me/desair/tus/server/upload/UploadInfo.java
@@ -156,7 +156,7 @@ public class UploadInfo implements Serializable {
    * @param length The number of bytes that the client specified he will upload
    */
   public void setLength(Long length) {
-    this.length = (length != null && length > 0 ? length : null);
+    this.length = (length != null && length >= 0 ? length : null);
   }
 
   /**

--- a/src/test/java/me/desair/tus/server/ITTusFileUploadService.java
+++ b/src/test/java/me/desair/tus/server/ITTusFileUploadService.java
@@ -271,6 +271,53 @@ public class ITTusFileUploadService {
   }
 
   @Test
+  public void testProcessZeroByteUpload() throws Exception {
+    // Create upload
+    servletRequest.setMethod("POST");
+    servletRequest.setRequestURI(UPLOAD_URI);
+    servletRequest.addHeader(HttpHeader.CONTENT_LENGTH, 0);
+    servletRequest.addHeader(HttpHeader.UPLOAD_LENGTH, 0);
+    servletRequest.addHeader(HttpHeader.TUS_RESUMABLE, "1.0.0");
+
+    tusFileUploadService.process(servletRequest, servletResponse, OWNER_KEY);
+    assertResponseHeaderNotBlank(HttpHeader.LOCATION);
+    assertResponseHeader(HttpHeader.TUS_RESUMABLE, "1.0.0");
+    assertResponseHeader(HttpHeader.CONTENT_LENGTH, "0");
+    assertResponseHeaderNotBlank(HttpHeader.UPLOAD_EXPIRES);
+    assertResponseStatus(HttpServletResponse.SC_CREATED);
+
+    String location =
+        UPLOAD_URI
+            + StringUtils.substringAfter(
+                servletResponse.getHeader(HttpHeader.LOCATION), UPLOAD_URI);
+
+    // Get upload info from service
+    UploadInfo info = tusFileUploadService.getUploadInfo(location, OWNER_KEY);
+    assertFalse(info.isUploadInProgress());
+    assertThat(info.getLength(), is(0L));
+    assertThat(info.getOffset(), is(0L));
+
+    // Get uploaded bytes from service
+    try (InputStream uploadedBytes = tusFileUploadService.getUploadedBytes(location, OWNER_KEY)) {
+      assertThat(IOUtils.toString(uploadedBytes, StandardCharsets.UTF_8), is(""));
+    }
+
+    // Make sure cleanup does not interfere with this test
+    tusFileUploadService.cleanup();
+
+    // Download the upload
+    reset();
+    servletRequest.setMethod("GET");
+    servletRequest.setRequestURI(location);
+
+    tusFileUploadService.process(servletRequest, servletResponse, OWNER_KEY);
+    assertResponseHeader(HttpHeader.TUS_RESUMABLE, "1.0.0");
+    assertResponseHeader(HttpHeader.CONTENT_LENGTH, "0");
+    assertResponseStatus(HttpServletResponse.SC_OK);
+    assertThat(servletResponse.getContentAsString(), is(""));
+  }
+
+  @Test
   public void testTerminateViaHttpRequest() throws Exception {
     String uploadContent = "This is my terminated test upload";
 


### PR DESCRIPTION
This PR fixes #73 

**Root cause**: When handling the Upload-Length header, UploadInfo.java was converting a length of 0 to null because it used the condition length > 0 instead of length >= 0. This caused the upload metadata to not store the actual length for 0-byte files, making the server think the upload was not finished yet.

**Changes made**: I updated the setter in UploadInfo.java to accept 0 as a valid file size (length >= 0).