### PR TITLE
Refactor: Replace deprecated org.apache.commons function calls

### DIFF
--- a/src/main/java/me/desair/tus/server/HttpMethod.java
+++ b/src/main/java/me/desair/tus/server/HttpMethod.java
@@ -26,7 +26,7 @@ public enum HttpMethod {
   /** Get the {@link HttpMethod} instance that matches the provided name. */
   public static HttpMethod forName(String name) {
     for (HttpMethod method : HttpMethod.values()) {
-      if (StringUtils.equalsIgnoreCase(method.name(), name)) {
+      if (method.name().equalsIgnoreCase(name)) {
         return method;
       }
     }

--- a/src/main/java/me/desair/tus/server/TusFileUploadService.java
+++ b/src/main/java/me/desair/tus/server/TusFileUploadService.java
@@ -253,7 +253,7 @@ public class TusFileUploadService {
   public TusFileUploadService disableTusExtension(String extensionName) {
     Validate.notNull(extensionName, "The extension name cannot be null");
     Validate.isTrue(
-        !StringUtils.equals("core", extensionName), "The core protocol cannot be disabled");
+        !"core".equals(extensionName), "The core protocol cannot be disabled");
 
     enabledFeatures.remove(extensionName);
     updateSupportedHttpMethods();

--- a/src/main/java/me/desair/tus/server/TusFileUploadService.java
+++ b/src/main/java/me/desair/tus/server/TusFileUploadService.java
@@ -29,7 +29,6 @@ import me.desair.tus.server.upload.disk.DiskStorageService;
 import me.desair.tus.server.util.TusServletRequest;
 import me.desair.tus.server.util.TusServletResponse;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -252,8 +251,7 @@ public class TusFileUploadService {
    */
   public TusFileUploadService disableTusExtension(String extensionName) {
     Validate.notNull(extensionName, "The extension name cannot be null");
-    Validate.isTrue(
-        !"core".equals(extensionName), "The core protocol cannot be disabled");
+    Validate.isTrue(!"core".equals(extensionName), "The core protocol cannot be disabled");
 
     enabledFeatures.remove(extensionName);
     updateSupportedHttpMethods();

--- a/src/main/java/me/desair/tus/server/checksum/ChecksumPatchRequestHandler.java
+++ b/src/main/java/me/desair/tus/server/checksum/ChecksumPatchRequestHandler.java
@@ -47,7 +47,7 @@ public class ChecksumPatchRequestHandler extends AbstractRequestHandler {
         ChecksumAlgorithm checksumAlgorithm = checksumInfo.getAlgorithm();
         String calculatedValue = servletRequest.getCalculatedChecksum(checksumAlgorithm);
 
-        if (!StringUtils.equals(expectedValue, calculatedValue)) {
+        if (!java.util.Objects.equals(expectedValue, calculatedValue)) {
           // throw an exception if the checksum is invalid. This will also trigger the removal
           // of any
           // bytes that were already saved

--- a/src/main/java/me/desair/tus/server/concatenation/ConcatenationPostRequestHandler.java
+++ b/src/main/java/me/desair/tus/server/concatenation/ConcatenationPostRequestHandler.java
@@ -41,10 +41,10 @@ public class ConcatenationPostRequestHandler extends AbstractRequestHandler {
     if (uploadInfo != null) {
 
       String uploadConcatValue = servletRequest.getHeader(HttpHeader.UPLOAD_CONCAT);
-      if (StringUtils.equalsIgnoreCase(uploadConcatValue, "partial")) {
+      if ("partial".equalsIgnoreCase(uploadConcatValue)) {
         uploadInfo.setUploadType(UploadType.PARTIAL);
 
-      } else if (StringUtils.startsWithIgnoreCase(uploadConcatValue, "final")) {
+      } else if (uploadConcatValue != null && uploadConcatValue.toLowerCase(java.util.Locale.ROOT).startsWith("final")) {
         // reset the length, just to be sure
         uploadInfo.setLength(null);
         uploadInfo.setUploadType(UploadType.CONCATENATED);

--- a/src/main/java/me/desair/tus/server/concatenation/ConcatenationPostRequestHandler.java
+++ b/src/main/java/me/desair/tus/server/concatenation/ConcatenationPostRequestHandler.java
@@ -11,7 +11,6 @@ import me.desair.tus.server.util.AbstractRequestHandler;
 import me.desair.tus.server.util.TusServletRequest;
 import me.desair.tus.server.util.TusServletResponse;
 import me.desair.tus.server.util.Utils;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * The Server MUST acknowledge a successful upload creation with the 201 Created status. The Server
@@ -44,7 +43,8 @@ public class ConcatenationPostRequestHandler extends AbstractRequestHandler {
       if ("partial".equalsIgnoreCase(uploadConcatValue)) {
         uploadInfo.setUploadType(UploadType.PARTIAL);
 
-      } else if (uploadConcatValue != null && uploadConcatValue.toLowerCase(java.util.Locale.ROOT).startsWith("final")) {
+      } else if (uploadConcatValue != null
+          && uploadConcatValue.toLowerCase(java.util.Locale.ROOT).startsWith("final")) {
         // reset the length, just to be sure
         uploadInfo.setLength(null);
         uploadInfo.setUploadType(UploadType.CONCATENATED);

--- a/src/main/java/me/desair/tus/server/concatenation/validation/NoUploadLengthOnFinalValidator.java
+++ b/src/main/java/me/desair/tus/server/concatenation/validation/NoUploadLengthOnFinalValidator.java
@@ -23,7 +23,7 @@ public class NoUploadLengthOnFinalValidator implements RequestValidator {
 
     String uploadConcatValue = request.getHeader(HttpHeader.UPLOAD_CONCAT);
 
-    if (StringUtils.startsWithIgnoreCase(uploadConcatValue, "final")
+    if (uploadConcatValue != null && uploadConcatValue.toLowerCase(java.util.Locale.ROOT).startsWith("final")
         && StringUtils.isNotBlank(request.getHeader(HttpHeader.UPLOAD_LENGTH))) {
 
       throw new UploadLengthNotAllowedOnConcatenationException(

--- a/src/main/java/me/desair/tus/server/concatenation/validation/NoUploadLengthOnFinalValidator.java
+++ b/src/main/java/me/desair/tus/server/concatenation/validation/NoUploadLengthOnFinalValidator.java
@@ -23,7 +23,8 @@ public class NoUploadLengthOnFinalValidator implements RequestValidator {
 
     String uploadConcatValue = request.getHeader(HttpHeader.UPLOAD_CONCAT);
 
-    if (uploadConcatValue != null && uploadConcatValue.toLowerCase(java.util.Locale.ROOT).startsWith("final")
+    if (uploadConcatValue != null
+        && uploadConcatValue.toLowerCase(java.util.Locale.ROOT).startsWith("final")
         && StringUtils.isNotBlank(request.getHeader(HttpHeader.UPLOAD_LENGTH))) {
 
       throw new UploadLengthNotAllowedOnConcatenationException(

--- a/src/main/java/me/desair/tus/server/concatenation/validation/PartialUploadsExistValidator.java
+++ b/src/main/java/me/desair/tus/server/concatenation/validation/PartialUploadsExistValidator.java
@@ -25,7 +25,7 @@ public class PartialUploadsExistValidator implements RequestValidator {
 
     String uploadConcatValue = request.getHeader(HttpHeader.UPLOAD_CONCAT);
 
-    if (StringUtils.startsWithIgnoreCase(uploadConcatValue, "final")) {
+    if (uploadConcatValue != null && uploadConcatValue.toLowerCase(java.util.Locale.ROOT).startsWith("final")) {
 
       for (String uploadUri : Utils.parseConcatenationIDsFromHeader(uploadConcatValue)) {
 

--- a/src/main/java/me/desair/tus/server/concatenation/validation/PartialUploadsExistValidator.java
+++ b/src/main/java/me/desair/tus/server/concatenation/validation/PartialUploadsExistValidator.java
@@ -10,7 +10,6 @@ import me.desair.tus.server.exception.TusException;
 import me.desair.tus.server.upload.UploadInfo;
 import me.desair.tus.server.upload.UploadStorageService;
 import me.desair.tus.server.util.Utils;
-import org.apache.commons.lang3.StringUtils;
 
 /** Validate that the IDs specified in the Upload-Concat header map to an existing upload */
 public class PartialUploadsExistValidator implements RequestValidator {
@@ -25,7 +24,8 @@ public class PartialUploadsExistValidator implements RequestValidator {
 
     String uploadConcatValue = request.getHeader(HttpHeader.UPLOAD_CONCAT);
 
-    if (uploadConcatValue != null && uploadConcatValue.toLowerCase(java.util.Locale.ROOT).startsWith("final")) {
+    if (uploadConcatValue != null
+        && uploadConcatValue.toLowerCase(java.util.Locale.ROOT).startsWith("final")) {
 
       for (String uploadUri : Utils.parseConcatenationIDsFromHeader(uploadConcatValue)) {
 

--- a/src/main/java/me/desair/tus/server/core/validation/TusResumableValidator.java
+++ b/src/main/java/me/desair/tus/server/core/validation/TusResumableValidator.java
@@ -9,7 +9,6 @@ import me.desair.tus.server.exception.InvalidTusResumableException;
 import me.desair.tus.server.exception.TusException;
 import me.desair.tus.server.upload.UploadStorageService;
 import me.desair.tus.server.util.Utils;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Class that will validate if the tus version in the request corresponds to our implementation

--- a/src/main/java/me/desair/tus/server/core/validation/TusResumableValidator.java
+++ b/src/main/java/me/desair/tus/server/core/validation/TusResumableValidator.java
@@ -32,7 +32,7 @@ public class TusResumableValidator implements RequestValidator {
       throws TusException {
 
     String requestVersion = Utils.getHeader(request, HttpHeader.TUS_RESUMABLE);
-    if (!StringUtils.equals(requestVersion, TusFileUploadService.TUS_API_VERSION)) {
+    if (!TusFileUploadService.TUS_API_VERSION.equals(requestVersion)) {
       throw new InvalidTusResumableException(
           "This server does not support tus protocol version " + requestVersion);
     }

--- a/src/main/java/me/desair/tus/server/core/validation/UploadOffsetValidator.java
+++ b/src/main/java/me/desair/tus/server/core/validation/UploadOffsetValidator.java
@@ -34,7 +34,7 @@ public class UploadOffsetValidator implements RequestValidator {
 
     if (uploadInfo != null) {
       String expectedOffset = Objects.toString(uploadInfo.getOffset());
-      if (!StringUtils.equals(expectedOffset, uploadOffset)) {
+      if (!java.util.Objects.equals(expectedOffset, uploadOffset)) {
         throw new UploadOffsetMismatchException(
             "The Upload-Offset was "
                 + StringUtils.trimToNull(uploadOffset)

--- a/src/main/java/me/desair/tus/server/creation/CreationPostRequestHandler.java
+++ b/src/main/java/me/desair/tus/server/creation/CreationPostRequestHandler.java
@@ -49,7 +49,7 @@ public class CreationPostRequestHandler extends AbstractRequestHandler {
     // It's important to return relative UPLOAD URLs in the Location header in order to support
     // HTTPS proxies
     // that sit in front of the web app
-    String url = uploadUri + (StringUtils.endsWith(uploadUri, "/") ? "" : "/") + info.getId();
+    String url = uploadUri + (uploadUri != null && uploadUri.endsWith("/") ? "" : "/") + info.getId();
     servletResponse.setHeader(HttpHeader.LOCATION, url);
     servletResponse.setStatus(HttpServletResponse.SC_CREATED);
 

--- a/src/main/java/me/desair/tus/server/creation/CreationPostRequestHandler.java
+++ b/src/main/java/me/desair/tus/server/creation/CreationPostRequestHandler.java
@@ -49,7 +49,8 @@ public class CreationPostRequestHandler extends AbstractRequestHandler {
     // It's important to return relative UPLOAD URLs in the Location header in order to support
     // HTTPS proxies
     // that sit in front of the web app
-    String url = uploadUri + (uploadUri != null && uploadUri.endsWith("/") ? "" : "/") + info.getId();
+    String url =
+        uploadUri + (uploadUri != null && uploadUri.endsWith("/") ? "" : "/") + info.getId();
     servletResponse.setHeader(HttpHeader.LOCATION, url);
     servletResponse.setStatus(HttpServletResponse.SC_CREATED);
 

--- a/src/main/java/me/desair/tus/server/creation/validation/UploadDeferLengthValidator.java
+++ b/src/main/java/me/desair/tus/server/creation/validation/UploadDeferLengthValidator.java
@@ -37,7 +37,7 @@ public class UploadDeferLengthValidator implements RequestValidator {
     }
 
     String uploadConcatValue = request.getHeader(HttpHeader.UPLOAD_CONCAT);
-    if (StringUtils.startsWithIgnoreCase(uploadConcatValue, "final")) {
+    if (uploadConcatValue != null && uploadConcatValue.toLowerCase(java.util.Locale.ROOT).startsWith("final")) {
       concatenatedUpload = true;
     }
 

--- a/src/main/java/me/desair/tus/server/creation/validation/UploadDeferLengthValidator.java
+++ b/src/main/java/me/desair/tus/server/creation/validation/UploadDeferLengthValidator.java
@@ -37,7 +37,8 @@ public class UploadDeferLengthValidator implements RequestValidator {
     }
 
     String uploadConcatValue = request.getHeader(HttpHeader.UPLOAD_CONCAT);
-    if (uploadConcatValue != null && uploadConcatValue.toLowerCase(java.util.Locale.ROOT).startsWith("final")) {
+    if (uploadConcatValue != null
+        && uploadConcatValue.toLowerCase(java.util.Locale.ROOT).startsWith("final")) {
       concatenatedUpload = true;
     }
 

--- a/src/main/java/me/desair/tus/server/upload/UploadIdFactory.java
+++ b/src/main/java/me/desair/tus/server/upload/UploadIdFactory.java
@@ -24,8 +24,8 @@ public abstract class UploadIdFactory {
    */
   public void setUploadUri(String uploadUri) {
     Validate.notBlank(uploadUri, "The upload URI pattern cannot be blank");
-    Validate.isTrue(StringUtils.startsWith(uploadUri, "/"), "The upload URI should start with /");
-    Validate.isTrue(!StringUtils.endsWith(uploadUri, "$"), "The upload URI should not end with $");
+    Validate.isTrue(uploadUri != null && uploadUri.startsWith("/"), "The upload URI should start with /");
+    Validate.isTrue(uploadUri != null && !uploadUri.endsWith("$"), "The upload URI should not end with $");
     this.uploadUri = uploadUri;
     this.uploadUriPattern = null;
   }
@@ -86,7 +86,7 @@ public abstract class UploadIdFactory {
       // We will extract the upload ID's by removing the upload URI from the start of the
       // request URI
       uploadUriPattern =
-          Pattern.compile("^.*" + uploadUri + (StringUtils.endsWith(uploadUri, "/") ? "" : "/?"));
+          Pattern.compile("^.*" + uploadUri + (uploadUri != null && uploadUri.endsWith("/") ? "" : "/?"));
     }
     return uploadUriPattern;
   }

--- a/src/main/java/me/desair/tus/server/upload/UploadIdFactory.java
+++ b/src/main/java/me/desair/tus/server/upload/UploadIdFactory.java
@@ -24,8 +24,10 @@ public abstract class UploadIdFactory {
    */
   public void setUploadUri(String uploadUri) {
     Validate.notBlank(uploadUri, "The upload URI pattern cannot be blank");
-    Validate.isTrue(uploadUri != null && uploadUri.startsWith("/"), "The upload URI should start with /");
-    Validate.isTrue(uploadUri != null && !uploadUri.endsWith("$"), "The upload URI should not end with $");
+    Validate.isTrue(
+        uploadUri != null && uploadUri.startsWith("/"), "The upload URI should start with /");
+    Validate.isTrue(
+        uploadUri != null && !uploadUri.endsWith("$"), "The upload URI should not end with $");
     this.uploadUri = uploadUri;
     this.uploadUriPattern = null;
   }
@@ -86,7 +88,8 @@ public abstract class UploadIdFactory {
       // We will extract the upload ID's by removing the upload URI from the start of the
       // request URI
       uploadUriPattern =
-          Pattern.compile("^.*" + uploadUri + (uploadUri != null && uploadUri.endsWith("/") ? "" : "/?"));
+          Pattern.compile(
+              "^.*" + uploadUri + (uploadUri != null && uploadUri.endsWith("/") ? "" : "/?"));
     }
     return uploadUriPattern;
   }

--- a/src/main/java/me/desair/tus/server/upload/disk/DiskStorageService.java
+++ b/src/main/java/me/desair/tus/server/upload/disk/DiskStorageService.java
@@ -58,13 +58,13 @@ public class DiskStorageService extends AbstractDiskBasedService implements Uplo
 
   public DiskStorageService(UploadIdFactory idFactory, String storagePath) {
     this(storagePath);
-    Validate.notNull(idFactory, "The IdFactory cannot be null");
+    java.util.Objects.requireNonNull(idFactory, "The IdFactory cannot be null");
     this.idFactory = idFactory;
   }
 
   @Override
   public void setIdFactory(UploadIdFactory idFactory) {
-    Validate.notNull(idFactory, "The IdFactory cannot be null");
+    java.util.Objects.requireNonNull(idFactory, "The IdFactory cannot be null");
     this.idFactory = idFactory;
   }
 
@@ -324,7 +324,7 @@ public class DiskStorageService extends AbstractDiskBasedService implements Uplo
 
   @Override
   public void setUploadConcatenationService(UploadConcatenationService concatenationService) {
-    Validate.notNull(concatenationService);
+    java.util.Objects.requireNonNull(concatenationService);
     this.uploadConcatenationService = concatenationService;
   }
 

--- a/src/main/java/me/desair/tus/server/upload/disk/DiskStorageService.java
+++ b/src/main/java/me/desair/tus/server/upload/disk/DiskStorageService.java
@@ -32,7 +32,6 @@ import me.desair.tus.server.upload.concatenation.UploadConcatenationService;
 import me.desair.tus.server.upload.concatenation.VirtualConcatenationService;
 import me.desair.tus.server.util.Utils;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/me/desair/tus/server/util/TusServletRequest.java
+++ b/src/main/java/me/desair/tus/server/util/TusServletRequest.java
@@ -18,12 +18,12 @@ import me.desair.tus.server.HttpHeader;
 import me.desair.tus.server.TusExtension;
 import me.desair.tus.server.checksum.ChecksumAlgorithm;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.input.CountingInputStream;
+import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.lang3.StringUtils;
 
 public class TusServletRequest extends HttpServletRequestWrapper {
 
-  private CountingInputStream countingInputStream;
+  private BoundedInputStream countingInputStream;
   private Map<ChecksumAlgorithm, DigestInputStream> digestInputStreamMap =
       new EnumMap<>(ChecksumAlgorithm.class);
 
@@ -67,7 +67,7 @@ public class TusServletRequest extends HttpServletRequestWrapper {
         contentInputStream = new HttpChunkedEncodingInputStream(contentInputStream, trailerHeaders);
       }
 
-      countingInputStream = new CountingInputStream(contentInputStream);
+      countingInputStream = BoundedInputStream.builder().setInputStream(contentInputStream).get();
       contentInputStream = countingInputStream;
 
       ChecksumAlgorithm checksumAlgorithm =
@@ -97,7 +97,7 @@ public class TusServletRequest extends HttpServletRequestWrapper {
   }
 
   public long getBytesRead() {
-    return countingInputStream == null ? 0 : countingInputStream.getByteCount();
+    return countingInputStream == null ? 0 : countingInputStream.getCount();
   }
 
   public boolean hasCalculatedChecksum() {
@@ -141,7 +141,7 @@ public class TusServletRequest extends HttpServletRequestWrapper {
   }
 
   private boolean hasChunkedTransferEncoding() {
-    return StringUtils.equalsIgnoreCase("chunked", getHeader(HttpHeader.TRANSFER_ENCODING));
+    return "chunked".equalsIgnoreCase(getHeader(HttpHeader.TRANSFER_ENCODING));
   }
 
   private MessageDigest getMessageDigest(ChecksumAlgorithm algorithm) {


### PR DESCRIPTION
Replaced deprecated third-party methods from `org.apache.commons.lang3` and `org.apache.commons.io` with modern standard Java alternatives and updated Apache Commons alternatives where appropriate.

- Replaced `CountingInputStream` with `BoundedInputStream` in `TusServletRequest`
- Replaced `StringUtils.equals`, `equalsIgnoreCase`, `startsWith`, `endsWith`, `startsWithIgnoreCase` with standard `String.equals`, `String.equalsIgnoreCase`, `String.startsWith`, `String.endsWith` and `java.util.Objects.equals` where applicable.
- Handled Locale appropriately during case-insensitive comparison (using `Locale.ROOT`).
- Replaced `Validate.notNull` with `java.util.Objects.requireNonNull` in `DiskStorageService`.

---
*PR created automatically by Jules for task [12419428033195704524](https://jules.google.com/task/12419428033195704524) started by @tomdesair*