### PR TITLE
Support lock release requests on DELETE HTTP requests

### DIFF
--- a/docs/LOCKING.md
+++ b/docs/LOCKING.md
@@ -11,10 +11,10 @@ In the `tus` protocol, client uploads can be resumed after network interruptions
 ### Stalled uploads and resume handling
 1. When a client performs an upload via a `PATCH` request, the server acquires an exclusive lock on that upload.
 2. If the client's network connection drops, the `PATCH` request connection might remain in a "half-open" state on the server (stalled socket read).
-3. The client, recognizing the disconnect, attempts to resume by sending a `HEAD` request to query the current offset.
-4. However, the stalled `PATCH` request is still running on the server and holding the lock, preventing the client from resuming.
+3. The client, recognizing the disconnect, attempts to resume by sending a `HEAD` request to query the current offset (or a `DELETE` request to terminate/clean up the upload).
+4. However, the stalled `PATCH` request is still running on the server and holding the lock, preventing the client from resuming or deleting.
 
-To solve this, we need a mechanism where a new `HEAD` request can trigger the release of the lock held by the stalled request, allowing immediate resumability.
+To solve this, we need a mechanism where a new `HEAD` or `DELETE` request can trigger the release of the lock held by the stalled request, allowing immediate resumability or deletion.
 
 ---
 
@@ -45,7 +45,7 @@ public interface UploadLockingService {
 - **Backward Compatibility**: Both `registerInputStream` and `requestLockRelease` are `default` (no-op) methods, ensuring that third-party custom implementations of `UploadLockingService` (e.g. S3, Redis, or Database backends) do not break.
 - **Request Flow**:
   - When a `PATCH` request stream is created, its input stream is wrapped in an `InterruptibleInputStream` and registered via `registerInputStream`.
-  - When a `HEAD` request encounters a lock conflict, it invokes `requestLockRelease`, which triggers the watchdog and/or local interruption.
+  - When a `HEAD` or `DELETE` request encounters a lock conflict, it invokes `requestLockRelease`, which triggers the watchdog and/or local interruption.
 
 ---
 

--- a/src/main/java/me/desair/tus/server/TusFileUploadService.java
+++ b/src/main/java/me/desair/tus/server/TusFileUploadService.java
@@ -338,7 +338,7 @@ public class TusFileUploadService {
         lock = uploadLockingService.lockUploadByUri(requestUri);
         break;
       } catch (TusException e) {
-        if (HttpMethod.HEAD.equals(method)) {
+        if (HttpMethod.HEAD.equals(method) || HttpMethod.DELETE.equals(method)) {
           uploadLockingService.requestLockRelease(requestUri);
           retries++;
           try {

--- a/src/test/java/me/desair/tus/server/TusFileUploadServiceTest.java
+++ b/src/test/java/me/desair/tus/server/TusFileUploadServiceTest.java
@@ -76,6 +76,46 @@ public class TusFileUploadServiceTest {
   }
 
   @Test
+  public void testAcquireUploadLockDeleteInterrupted() throws Exception {
+    UploadLockingService mockLockingService = mock(UploadLockingService.class);
+    when(mockLockingService.lockUploadByUri(anyString()))
+        .thenThrow(new UploadAlreadyLockedException("Locked"));
+
+    TusFileUploadService service =
+        new TusFileUploadService().withUploadLockingService(mockLockingService);
+
+    // Interrupt the thread to trigger InterruptedException during sleep
+    Thread.currentThread().interrupt();
+
+    try {
+      service.acquireUploadLock(HttpMethod.DELETE, "/files/test");
+      fail("Expected IOException due to thread interruption");
+    } catch (IOException e) {
+      // Clear interrupted flag so it doesn't leak to other tests
+      Thread.interrupted();
+      assertNotNull(e.getCause());
+    }
+  }
+
+  @Test
+  public void testAcquireUploadLockDeleteFallback() throws Exception {
+    UploadLockingService mockLockingService = mock(UploadLockingService.class);
+    UploadLock mockLock = mock(UploadLock.class);
+
+    var stubbing = when(mockLockingService.lockUploadByUri(anyString()));
+    for (int i = 0; i < 25; i++) {
+      stubbing = stubbing.thenThrow(new UploadAlreadyLockedException("Locked"));
+    }
+    stubbing.thenReturn(mockLock);
+
+    TusFileUploadService service =
+        new TusFileUploadService().withUploadLockingService(mockLockingService);
+
+    UploadLock lock = service.acquireUploadLock(HttpMethod.DELETE, "/files/test");
+    assertNotNull(lock);
+  }
+
+  @Test
   public void testProcessSuccess() throws Exception {
     UploadLockingService mockLockingService = mock(UploadLockingService.class);
     UploadLock mockLock = mock(UploadLock.class);


### PR DESCRIPTION
This pull request updates the `acquireUploadLock` function in `TusFileUploadService` so that a lock release can be requested on a `DELETE` HTTP request, similar to the existing `HEAD` request behavior.

### Changes:
1. **TusFileUploadService**: Updated `acquireUploadLock` to handle lock release and retry logic for both `HttpMethod.HEAD` and `HttpMethod.DELETE` requests.
2. **TusFileUploadServiceTest**: Added `testAcquireUploadLockDeleteFallback` and `testAcquireUploadLockDeleteInterrupted` unit tests.
3. **Documentation**: Updated `docs/LOCKING.md` to reflect support for `DELETE` request lock releases.

All modified lines are 100% covered by the added unit tests, and all checks pass.