### PR TITLE
fix: Set Github workflow permissions to read as default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@
 
 name: Build and Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["master"]

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -8,6 +8,9 @@
 
 name: Google Java Codestyle
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["master"]


### PR DESCRIPTION
Set Github workflow permissions to read as default