### PR TITLE
fix: grant contents: write permission to mvn-install job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@
 
 name: Build and Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["master"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ on:
 
 jobs:
   mvn-install:
+    permissions:
+      contents: write
     strategy:
       matrix:
         java: [17, 21, 25]

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -8,6 +8,9 @@
 
 name: Google Java Codestyle
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["master"]


### PR DESCRIPTION
Enables the Update dependency graph step to submit dependency snapshots.