### PR TITLE
🔒 Fix Path Traversal Vulnerability in Disk Storage Service

### DIFF
--- a/src/main/java/me/desair/tus/server/upload/disk/AbstractDiskBasedService.java
+++ b/src/main/java/me/desair/tus/server/upload/disk/AbstractDiskBasedService.java
@@ -37,7 +37,11 @@ public class AbstractDiskBasedService {
     if (id == null) {
       return null;
     } else {
-      return storagePath.resolve(id.toString());
+      Path uploadPath = storagePath.resolve(id.toString()).normalize();
+      if (!uploadPath.toAbsolutePath().startsWith(storagePath.toAbsolutePath().normalize())) {
+        throw new IllegalArgumentException("Invalid upload ID");
+      }
+      return uploadPath;
     }
   }
 


### PR DESCRIPTION
🎯 **What:** 
Fixed a path traversal vulnerability in `AbstractDiskBasedService.java` where `id` strings were unsafely resolved against the storage path.

⚠️ **Risk:** 
By crafting a malicious ID containing directory climbing sequences like `../` or absolute paths, attackers could potentially write or read files arbitrarily outside the intended upload directory, which is a significant security risk.

🛡️ **Solution:** 
Modified `getPathInStorageDirectory(UploadId id)` to `normalize()` both the resulting `uploadPath` and the base `storagePath`. It explicitly enforces that `uploadPath.toAbsolutePath()` begins with `storagePath.toAbsolutePath().normalize()` via `startsWith()`, throwing an `IllegalArgumentException` on validation failure.

---
*PR created automatically by Jules for task [8619812930252771219](https://jules.google.com/task/8619812930252771219) started by @tomdesair*