### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in AbstractDiskBasedService

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-16 - [Fix path traversal vulnerability in disk storage service]
+**Vulnerability:** Path traversal vulnerability in `AbstractDiskBasedService`. The method `getPathInStorageDirectory(UploadId id)` resolved the path dynamically from `id.toString()` without bounds checking, which could allow an attacker to read/write arbitrary files given an ID payload containing directory traversal sequences `..` or URL encoded path variants (`%2E%2E`).
+**Learning:** `URLCodec.encode` might not correctly sanitize path traversal characters. An attacker can set an ID value like `..`, which would bypass the encode step because `.decode("..")` evaluates to `..`. Therefore, input sanitization should verify the absolute directory boundaries.
+**Prevention:** Use Java `java.nio.file.Path` to resolve the full absolute path and ensure the path is within bounds using `startsWith()` logic on normalized absolute paths.

--- a/src/main/java/me/desair/tus/server/upload/disk/AbstractDiskBasedService.java
+++ b/src/main/java/me/desair/tus/server/upload/disk/AbstractDiskBasedService.java
@@ -37,7 +37,12 @@ public class AbstractDiskBasedService {
     if (id == null) {
       return null;
     } else {
-      return storagePath.resolve(id.toString());
+      Path resolvedPath = storagePath.resolve(id.toString());
+      Path normalizedStoragePath = storagePath.toAbsolutePath().normalize();
+      if (!resolvedPath.toAbsolutePath().normalize().startsWith(normalizedStoragePath)) {
+        throw new IllegalArgumentException("Upload ID violates storage path boundaries");
+      }
+      return resolvedPath;
     }
   }
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path traversal vulnerability in `AbstractDiskBasedService.getPathInStorageDirectory`. It was resolving user-supplied UploadId values against the base directory without checking if the resulting path escaped the storage boundary. Additionally, the `UploadId` class's encoding logic does not prevent URL-safe characters like `.` from being used.
🎯 **Impact:** An attacker could craft a malicious `UploadId` (e.g. `../../../etc/passwd` or encoded variants) causing the server to read or overwrite arbitrary files on the disk, completely compromising the system.
🔧 **Fix:** Refactored `getPathInStorageDirectory` to normalize the resolved absolute path and verify it begins with the normalized absolute `storagePath` using `Path.startsWith()`. If it escapes the directory, an `IllegalArgumentException` is thrown.
✅ **Verification:** Unit tests execution via `mvn test` pass without regressions. Run `mvn test` to verify.

---
*PR created automatically by Jules for task [14854299696497648661](https://jules.google.com/task/14854299696497648661) started by @tomdesair*