### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure deserialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Insecure Deserialization Fix]
+**Vulnerability:** The `Utils.readSerializable` function deserialized objects directly from `ObjectInputStream`, which can lead to insecure deserialization attacks if the stored data is tampered with.
+**Learning:** `commons-io` provides `ValidatingObjectInputStream` to limit deserialization to specific allowed classes (`java.lang.*`, `java.util.*`, `me.desair.tus.server.upload.*`, `me.desair.tus.server.checksum.*`).
+**Prevention:** Always use `ValidatingObjectInputStream` or equivalent mechanisms to restrict class loading when deserializing data, even if it comes from local storage, to prevent arbitrary code execution in case the storage layer is compromised.

--- a/src/main/java/me/desair/tus/server/util/Utils.java
+++ b/src/main/java/me/desair/tus/server/util/Utils.java
@@ -8,7 +8,6 @@ import static java.nio.file.StandardOpenOption.WRITE;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
@@ -22,6 +21,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import me.desair.tus.server.HttpHeader;
 import me.desair.tus.server.checksum.ChecksumAlgorithm;
+import org.apache.commons.io.serialization.ValidatingObjectInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,7 +83,13 @@ public class Utils {
         // Lock will be released when the channel is closed
         if (lockFileShared(channel) != null) {
 
-          try (ObjectInputStream ois = new ObjectInputStream(Channels.newInputStream(channel))) {
+          try (ValidatingObjectInputStream ois =
+              new ValidatingObjectInputStream(Channels.newInputStream(channel))) {
+            ois.accept(clazz);
+            ois.accept("java.lang.*");
+            ois.accept("java.util.*");
+            ois.accept("me.desair.tus.server.upload.*");
+            ois.accept("me.desair.tus.server.checksum.*");
             info = clazz.cast(ois.readObject());
           } catch (ClassNotFoundException
               | java.io.EOFException


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Insecure deserialization in `Utils.readSerializable` via raw `ObjectInputStream`.
🎯 Impact: Could allow an attacker to execute arbitrary code if they can tamper with the serialized files stored on disk.
🔧 Fix: Replaced `ObjectInputStream` with `ValidatingObjectInputStream` from `commons-io` to restrict deserialization to allowed classes (`java.lang.*`, `java.util.*`, `me.desair.tus.server.upload.*`, `me.desair.tus.server.checksum.*`).
✅ Verification: Ran unit tests to ensure deserialization of valid objects still works.

---
*PR created automatically by Jules for task [4825287769009940094](https://jules.google.com/task/4825287769009940094) started by @tomdesair*