### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Insecure Deserialization Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-06-29 - [Fix Insecure Deserialization in DiskStorageService]
+**Vulnerability:** The application was using the standard `java.io.ObjectInputStream` to deserialize objects from disk (specifically in `Utils.readSerializable`), without restricting the classes that can be instantiated. This creates a critical insecure deserialization vulnerability that could lead to Remote Code Execution (RCE) if an attacker can tamper with the serialized files on disk.
+**Learning:** The vulnerability existed because standard deserialization is dangerous by default and implicitly trusts the incoming data to dictate which classes are instantiated.
+**Prevention:** Always use a validating deserialization mechanism, such as Apache Commons IO `ValidatingObjectInputStream`, to explicitly allowlist only the classes and packages that are safe and expected to be deserialized.

--- a/src/main/java/me/desair/tus/server/util/Utils.java
+++ b/src/main/java/me/desair/tus/server/util/Utils.java
@@ -8,7 +8,6 @@ import static java.nio.file.StandardOpenOption.WRITE;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
@@ -22,6 +21,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import me.desair.tus.server.HttpHeader;
 import me.desair.tus.server.checksum.ChecksumAlgorithm;
+import org.apache.commons.io.serialization.ValidatingObjectInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,7 +83,21 @@ public class Utils {
         // Lock will be released when the channel is closed
         if (lockFileShared(channel) != null) {
 
-          try (ObjectInputStream ois = new ObjectInputStream(Channels.newInputStream(channel))) {
+          try (ValidatingObjectInputStream ois =
+              new ValidatingObjectInputStream(Channels.newInputStream(channel))) {
+            ois.accept(
+                clazz,
+                String.class,
+                Number.class,
+                Long.class,
+                Integer.class,
+                Short.class,
+                Byte.class,
+                Double.class,
+                Float.class,
+                Boolean.class,
+                Character.class);
+            ois.accept("java.lang.*", "java.util.*", "me.desair.tus.server.*");
             info = clazz.cast(ois.readObject());
           } catch (ClassNotFoundException
               | java.io.EOFException


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:** The application was using the standard `java.io.ObjectInputStream` to deserialize objects from disk (specifically in `Utils.readSerializable`), without restricting the classes that can be instantiated. This creates a critical insecure deserialization vulnerability.

🎯 **Impact:** If an attacker can tamper with the serialized files on disk, they could instantiate arbitrary classes (gadget chains) that could lead to Remote Code Execution (RCE).

🔧 **Fix:** Replaced the standard `ObjectInputStream` with Apache Commons IO's `ValidatingObjectInputStream` and implemented a strict allowlist. Only standard Java primitive wrappers, basic language features (`java.lang.*`), collections (`java.util.*`), and the application's internal models (`me.desair.tus.server.*`) are allowed to be deserialized.

✅ **Verification:** Run `mvn test` to verify that all unit tests pass, ensuring that legitimate objects are successfully deserialized without regressions.

---
*PR created automatically by Jules for task [16965681493920024994](https://jules.google.com/task/16965681493920024994) started by @tomdesair*