### PR TITLE
🧪 Add explicit DecoderException test in UploadId constructor

### DIFF
--- a/src/test/java/me/desair/tus/server/upload/UploadIdTest.java
+++ b/src/test/java/me/desair/tus/server/upload/UploadIdTest.java
@@ -60,6 +60,13 @@ public class UploadIdTest {
   }
 
   @Test
+  public void testConstructorWithDecoderException() {
+    String malformedUrlStr = "%zz";
+    UploadId id = new UploadId(malformedUrlStr);
+    assertEquals("%zz", id.toString());
+  }
+
+  @Test
   public void equalsSameUrlSafeValue() {
     UploadId id1 = new UploadId("id%2F1");
     UploadId id2 = new UploadId("id/1");


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing error test for `DecoderException` in `UploadId` constructor.
📊 **Coverage:** What scenarios are now tested: A malformed URL string starting with `%` but not followed by valid hex characters (e.g. `%zz`) which throws a `DecoderException` and triggers the fallback branch.
✨ **Result:** The improvement in test coverage: We now explicitly cover the catch block for `DecoderException` and verify the value is assigned correctly as-is.

---
*PR created automatically by Jules for task [4778707476590793195](https://jules.google.com/task/4778707476590793195) started by @tomdesair*