### PR TITLE
🧹 Refactor `LockWatchdogRunnable.run()` for improved readability

### DIFF
--- a/src/main/java/me/desair/tus/server/upload/disk/DiskLockingService.java
+++ b/src/main/java/me/desair/tus/server/upload/disk/DiskLockingService.java
@@ -225,44 +225,10 @@ public class DiskLockingService extends AbstractDiskBasedService implements Uplo
             break;
           }
 
-          // Check stop files for each active lock
-          for (Map.Entry<String, WeakReference<InterruptibleInputStream>> entry :
-              activeLocks.entrySet()) {
-            String idStr = entry.getKey();
-            WeakReference<InterruptibleInputStream> ref = entry.getValue();
-            InterruptibleInputStream stream = ref.get();
+          checkActiveLocks();
 
-            if (stream == null) {
-              activeLocks.remove(idStr);
-              continue;
-            }
-
-            Path stopFilePath = getStopPath(new UploadId(idStr));
-            if (stopFilePath != null && Files.exists(stopFilePath)) {
-              try {
-                log.info(
-                    "Watchdog detected stop file for upload ID {}. Interrupting stream.", idStr);
-                stream.interrupt();
-              } catch (Throwable t) {
-                log.warn("Error interrupting stream for ID " + idStr, t);
-              }
-              activeLocks.remove(idStr);
-              try {
-                Files.deleteIfExists(stopFilePath);
-              } catch (IOException e) {
-                // ignore
-              }
-            }
-          }
-
-          // Thread-safe check to decide whether to exit
-          if (activeLocks.isEmpty()) {
-            synchronized (watchdogLock) {
-              if (activeLocks.isEmpty()) {
-                watchdogThread = null;
-                break;
-              }
-            }
+          if (shouldExitWatchdog()) {
+            break;
           }
         }
       } catch (Throwable t) {
@@ -271,6 +237,54 @@ public class DiskLockingService extends AbstractDiskBasedService implements Uplo
           watchdogThread = null;
         }
       }
+    }
+
+    private void checkActiveLocks() {
+      // Check stop files for each active lock
+      for (Map.Entry<String, WeakReference<InterruptibleInputStream>> entry :
+          activeLocks.entrySet()) {
+        String idStr = entry.getKey();
+        WeakReference<InterruptibleInputStream> ref = entry.getValue();
+        InterruptibleInputStream stream = ref.get();
+
+        if (stream == null) {
+          activeLocks.remove(idStr);
+          continue;
+        }
+
+        checkStopFileAndInterrupt(idStr, stream);
+      }
+    }
+
+    private void checkStopFileAndInterrupt(String idStr, InterruptibleInputStream stream) {
+      Path stopFilePath = getStopPath(new UploadId(idStr));
+      if (stopFilePath != null && Files.exists(stopFilePath)) {
+        try {
+          log.info("Watchdog detected stop file for upload ID {}. Interrupting stream.", idStr);
+          stream.interrupt();
+        } catch (Throwable t) {
+          log.warn("Error interrupting stream for ID " + idStr, t);
+        }
+        activeLocks.remove(idStr);
+        try {
+          Files.deleteIfExists(stopFilePath);
+        } catch (IOException e) {
+          // ignore
+        }
+      }
+    }
+
+    private boolean shouldExitWatchdog() {
+      // Thread-safe check to decide whether to exit
+      if (activeLocks.isEmpty()) {
+        synchronized (watchdogLock) {
+          if (activeLocks.isEmpty()) {
+            watchdogThread = null;
+            return true;
+          }
+        }
+      }
+      return false;
     }
   }
 


### PR DESCRIPTION
🎯 **What:** Extracted the complex nested logic inside the `run()` method of `LockWatchdogRunnable` (within `DiskLockingService`) into three smaller, well-named private helper methods: `checkActiveLocks()`, `checkStopFileAndInterrupt()`, and `shouldExitWatchdog()`.

💡 **Why:** The original `run()` method contained a significant amount of indentation and nested loop logic handling stop file checks, stream interruptions, and thread-safe termination. Refactoring this into modular helpers dramatically improves readability and long-term maintainability without changing any functionality.

✅ **Verification:** Verified that the logic remained functionally identical. Ran `mvn com.spotify.fmt:fmt-maven-plugin:format` to ensure code formatting was preserved. Ran the entire test suite via `mvn clean test` and specifically `DiskLockingServiceTest`. Verified no new lines dropped coverage via `mvn verify -Pcheck-coverage -Djacoco.compare.branch=master`.

✨ **Result:** A cleaner, much more readable `LockWatchdogRunnable` with the same robust lock cleanup capabilities.

---
*PR created automatically by Jules for task [6962994243959913544](https://jules.google.com/task/6962994243959913544) started by @tomdesair*