### PR TITLE
Fix unsafe checksum path traversal and add agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Completed parent uploads are indexed by checksum under the `<storagePath>/checks
 
 ### 6. Unit Test Coverage
 - Unit test coverage must remain high. All new code (including background watchdog threads, helper methods, stream wrappers, and retry logic) must be thoroughly unit tested.
+- Do not use reflection to test private helper methods. Always test code through public API boundaries instead of bypassing encapsulation.
 - After finalizing any implementation, you MUST check the unit test coverage on new/modified lines by running:
   ```bash
   mvn verify -Pcheck-coverage -Djacoco.compare.branch=master

--- a/src/main/java/me/desair/tus/server/upload/disk/DiskStorageService.java
+++ b/src/main/java/me/desair/tus/server/upload/disk/DiskStorageService.java
@@ -448,12 +448,26 @@ public class DiskStorageService extends AbstractDiskBasedService implements Uplo
     return getPathInUploadDir(id, INFO_FILE);
   }
 
-  private Path getChecksumPath(String checksum, ChecksumAlgorithm algorithm) {
+  private Path getChecksumPath(String checksum, ChecksumAlgorithm algorithm) throws IOException {
+    if (!isSafePathComponent(checksum)) {
+      throw new IOException("The checksum contains an unsafe value.");
+    }
+    if (algorithm == null || !isSafePathComponent(algorithm.toString())) {
+      throw new IOException("The checksum algorithm contains an unsafe value.");
+    }
     return getStoragePath()
         .getParent()
         .resolve("checksums")
         .resolve(algorithm.toString())
         .resolve(checksum);
+  }
+
+  private boolean isSafePathComponent(String component) {
+    return component != null
+        && !component.trim().isEmpty()
+        && !component.contains("/")
+        && !component.contains("\\")
+        && !component.contains("..");
   }
 
   private Path createUploadDirectory(UploadId id) throws IOException {
@@ -464,6 +478,9 @@ public class DiskStorageService extends AbstractDiskBasedService implements Uplo
     // Get the upload directory
     Path uploadDir = getPathInStorageDirectory(id);
     if (uploadDir != null && Files.exists(uploadDir)) {
+      if (!isSafePathComponent(fileName)) {
+        throw new IllegalArgumentException("The file name contains an unsafe value.");
+      }
       return uploadDir.resolve(fileName);
     } else {
       throw new UploadNotFoundException("The upload for id " + id + " was not found.");

--- a/src/test/java/me/desair/tus/server/upload/disk/DiskStorageServiceTest.java
+++ b/src/test/java/me/desair/tus/server/upload/disk/DiskStorageServiceTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -24,6 +25,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import me.desair.tus.server.exception.InvalidUploadOffsetException;
 import me.desair.tus.server.exception.UploadNotFoundException;
@@ -732,5 +735,55 @@ public class DiskStorageServiceTest {
 
     // Cleanup
     FileUtils.deleteDirectory(nonExistentPath.toFile());
+  }
+
+  @Test
+  public void testGetUploadInfoByChecksumWithUnsafeChecksums() {
+    List<String> unsafeChecksums =
+        Arrays.asList(" ", "../test", "test/../test", "test/test", "test\\test", "..", "/");
+
+    for (String checksum : unsafeChecksums) {
+      assertThrows(
+          IOException.class,
+          () -> {
+            storageService.getUploadInfoByChecksum(
+                checksum, me.desair.tus.server.checksum.ChecksumAlgorithm.SHA256);
+          });
+    }
+  }
+
+  @Test
+  public void testUpdateWithUnsafeChecksums() throws Exception {
+    storageService.setUploadDeduplicationEnabled(true);
+
+    UploadInfo info = new UploadInfo();
+    info.setLength(100L);
+    info.setOffset(100L);
+    info = storageService.create(info, null);
+    info.setOffset(100L);
+
+    info.setChecksum("test/path");
+    info.setChecksumAlgorithm(me.desair.tus.server.checksum.ChecksumAlgorithm.SHA256);
+
+    final UploadInfo finalInfo = info;
+    assertThrows(
+        IOException.class,
+        () -> {
+          storageService.update(finalInfo);
+        });
+  }
+
+  @Test
+  public void testTerminateUploadWithUnsafeChecksums() throws Exception {
+    UploadInfo info = new UploadInfo();
+    info.setId(new UploadId("test-id"));
+    info.setChecksum("test/path");
+    info.setChecksumAlgorithm(me.desair.tus.server.checksum.ChecksumAlgorithm.SHA256);
+
+    assertThrows(
+        IOException.class,
+        () -> {
+          storageService.terminateUpload(info);
+        });
   }
 }


### PR DESCRIPTION
Fixes the path traversal vulnerability in getChecksumPath where a checksum value is transformed to a file system path, by validating that all components are safe using a new helper `isSafePathComponent`. Also adds tests for unsafe checksum handling, and updates developer guidelines in AGENTS.md.