### PR TITLE
Fix SonarCloud reliability and security hotspot issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
 
       - if: ${{ matrix.run-coveralls }}
         name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329
         with:
           # *base-path* is prepended to all paths in order to correctly reference source files on coveralls.io
           base-path: src/main/java

--- a/src/main/java/me/desair/tus/server/rufh/validation/RufhAppendValidator.java
+++ b/src/main/java/me/desair/tus/server/rufh/validation/RufhAppendValidator.java
@@ -53,6 +53,10 @@ public class RufhAppendValidator implements RequestValidator {
       String ownerKey)
       throws TusException, IOException {
 
+    if (uploadStorageService == null) {
+      return;
+    }
+
     String requestUri = request.getRequestURI();
     boolean isCreationEndpoint = Utils.isCreationEndpoint(request, uploadStorageService);
     UploadInfo uploadInfo = uploadStorageService.getUploadInfo(requestUri, ownerKey);

--- a/src/test/java/me/desair/tus/server/rufh/validation/RufhAppendValidatorTest.java
+++ b/src/test/java/me/desair/tus/server/rufh/validation/RufhAppendValidatorTest.java
@@ -113,6 +113,12 @@ public class RufhAppendValidatorTest {
     validator.validate(HttpMethod.PATCH, request, storageService, "owner");
   }
 
+  @Test
+  public void testValidateStorageServiceNull() throws Exception {
+    // Should return immediately without exception
+    validator.validate(HttpMethod.PATCH, request, null, "owner");
+  }
+
   @Test(expected = TusException.class)
   public void testValidateMismatchingUploadLength() throws Exception {
     request.setRequestURI("/files/exists");


### PR DESCRIPTION
This branch resolves SonarCloud issues reported for the `tus-java-server` project.

**Reliability fix:**
Added a check to exit early in `RufhAppendValidator.validate` if `uploadStorageService` is null, resolving a potential NullPointerException highlighted by SonarCloud. Added a corresponding unit test to maintain 100% test coverage.

**Security hotspot fix:**
Pinned the `coverallsapp/github-action` GitHub Action to its exact commit SHA (v2.3.8) in `.github/workflows/build.yml` instead of the generic `v2` tag, improving the supply-chain security posture.

---
*PR created automatically by Jules for task [2851799642143350705](https://jules.google.com/task/2851799642143350705) started by @tomdesair*